### PR TITLE
src/common.h: fix le32(x) for big-endian architectures

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -468,10 +468,10 @@ time_t td_ntfs2utc (int64_t ntfstime);
 #define le24(x) ((((x) & 0x000000ffUL) << 16) | \
     ((x) & 0x0000ff00UL)        | \
     (((x) & 0x00ff0000UL) >> 16))
-#define le32(x)  ((((x)&0xff000000L)>>24)                | \
-    (((x)&0x00ff0000L)>>8)                  | \
-    (((x)&0x0000ff00L)<<8)                  | \
-    (((x)&0x000000ffL)<<24))
+#define le32(x)  ((((x)&0xff000000UL)>>24)                | \
+    (((x)&0x00ff0000UL)>>8)                  | \
+    (((x)&0x0000ff00UL)<<8)                  | \
+    (((x)&0x000000ffUL)<<24))
 #define be32(x)  (x)
 #define le64(x)  ((((x)&0xff00000000000000LL)>>56)       | \
     (((x)&0x00ff000000000000LL)>>40)        | \


### PR DESCRIPTION
testdisk FTBFS on Debian for mips (and other big-endian architectures) with following error:
```
common.h:128:2: error: initializer element is not constant
  ((efi_guid_t){le32(0x516e7cb4),le16(0x6ecf),le16(0x11d6),0x8f,0xf8,{0x00,0x02,0x2d,0x09,0x71,0x2b}})
  ^
partgpt.c:80:5: note: in expansion of macro 'GPT_ENT_TYPE_FREEBSD'
   { GPT_ENT_TYPE_FREEBSD,  "FreeBSD"  },
     ^~~~~~~~~~~~~~~~~~~~
common.h:128:2: note: (near initialization for 'gpt_sys_types[2].part_type')
  ((efi_guid_t){le32(0x516e7cb4),le16(0x6ecf),le16(0x11d6),0x8f,0xf8,{0x00,0x02,0x2d,0x09,0x71,0x2b}})
  ^
partgpt.c:80:5: note: in expansion of macro 'GPT_ENT_TYPE_FREEBSD'
   { GPT_ENT_TYPE_FREEBSD,  "FreeBSD"  },
     ^~~~~~~~~~~~~~~~~~~~
```
build log: https://buildd.debian.org/status/fetch.php?pkg=testdisk&arch=mips&ver=7.0-2&stamp=1481458955

The problem was in bitwise with signed values in le32 macro.

With this patch I was able to build testdisk successfully on mips.