### PR TITLE
Digital Ocean /dev/vda support

### DIFF
--- a/src/hdaccess.c
+++ b/src/hdaccess.c
@@ -406,6 +406,7 @@ list_disk_t *hd_parse(list_disk_t *list_disk, const int verbose, const int testd
     char device_scsi_hd[]="/dev/da0";
     char device_cd[]="/dev/acd0";
     char device_vnd[]="/dev/rsvnd0c";	/* virtual node driver, interface to a disk image file */
+    char device_scsi_do[]="/dev/vda0";  /* digital ocean virtual disk */	  
     /* wd da */
     /* Disk IDE */
     for(i=0;i<8;i++)
@@ -466,6 +467,12 @@ list_disk_t *hd_parse(list_disk_t *list_disk, const int verbose, const int testd
     {
       device_vnd[strlen(device_vnd)-2]='0'+i;
       list_disk=insert_new_disk(list_disk, file_test_availability(device_vnd, verbose, testdisk_mode));
+    }
+    /* Digital Ocean */
+    for(i=0;i<8;i++)
+    {
+      device_scsi_do[strlen(device_scsi_do)-1]='0'+i;
+      list_disk=insert_new_disk(list_disk, file_test_availability(device_scsi_do, verbose, testdisk_mode));
     }
   }
 #endif


### PR DESCRIPTION
Was getting no disk found

```
root@SERVERNAME:~# df
Filesystem     1K-blocks     Used Available Use% Mounted on
/dev/vda1       41282880 12868100  26317732  33% /
udev             1021904        4   1021900   1% /dev
tmpfs             410280      228    410052   1% /run
none                5120        0      5120   0% /run/lock
none             1025692        0   1025692   0% /run/shm
none              102400        0    102400   0% /run/user
```

