### PR TITLE
Corrects family misspelt with two 'l' as familly

### DIFF
--- a/src/lang/qphotorec.ca.ts
+++ b/src/lang/qphotorec.ca.ts
@@ -192,7 +192,7 @@ detecció a la BIOS, i instal·leu la última versió dels controladors del disc
     </message>
     <message>
         <location filename="src/qphotorec.cpp" line="750"/>
-        <source>File familly</source>
+        <source>File family</source>
         <translation>Família de fitxers</translation>
     </message>
     <message>

--- a/src/lang/qphotorec.es.ts
+++ b/src/lang/qphotorec.es.ts
@@ -187,7 +187,7 @@ detection, and install the latest OS patches and disk drivers.</source>
     </message>
     <message>
         <location filename="src/qphotorec.cpp" line="750"/>
-        <source>File familly</source>
+        <source>File family</source>
         <translation>Familia de archivos</translation>
     </message>
     <message>

--- a/src/lang/qphotorec.fr.ts
+++ b/src/lang/qphotorec.fr.ts
@@ -191,7 +191,7 @@ Si un disque listé ci dessus a une taille incorrecte, vérifier le paramétrage
     </message>
     <message>
         <location filename="src/qphotorec.cpp" line="750"/>
-        <source>File familly</source>
+        <source>File family</source>
         <translation>Familles de fichier</translation>
     </message>
     <message>

--- a/src/lang/qphotorec.it.ts
+++ b/src/lang/qphotorec.it.ts
@@ -193,7 +193,7 @@ detection, e installare gli aggiornamenti del sistema operativo e i driver del d
     </message>
     <message>
         <location filename="src/qphotorec.cpp" line="750"/>
-        <source>File familly</source>
+        <source>File family</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/src/lang/qphotorec.pt.ts
+++ b/src/lang/qphotorec.pt.ts
@@ -192,7 +192,7 @@ detecar, e instalar o ultimo patch do SO e drivers do disco.</translation>
     </message>
     <message>
         <location filename="src/qphotorec.cpp" line="750"/>
-        <source>File familly</source>
+        <source>File family</source>
         <translation>Familia do arquivo</translation>
     </message>
     <message>

--- a/src/lang/qphotorec.ru.ts
+++ b/src/lang/qphotorec.ru.ts
@@ -192,7 +192,7 @@ detection, and install the latest OS patches and disk drivers.</source>
     </message>
     <message>
         <location filename="src/qphotorec.cpp" line="750"/>
-        <source>File familly</source>
+        <source>File family</source>
         <translation>Семейство файлов</translation>
     </message>
     <message>

--- a/src/lang/qphotorec.zh_TW.ts
+++ b/src/lang/qphotorec.zh_TW.ts
@@ -192,7 +192,7 @@ detection, and install the latest OS patches and disk drivers.</source>
     </message>
     <message>
         <location filename="src/qphotorec.cpp" line="750"/>
-        <source>File familly</source>
+        <source>File family</source>
         <translation>檔案家族</translation>
     </message>
     <message>

--- a/src/qphotorec.cpp
+++ b/src/qphotorec.cpp
@@ -750,7 +750,7 @@ void QPhotorec::qphotorec_search_setupUI()
   progressWidget2->setLayout(progressWidgetLayout2);
 
   QStringList oLabel;
-  oLabel.append(tr("File familly"));
+  oLabel.append(tr("File family"));
   oLabel.append(tr("Number of files recovered"));
 
   filestatsWidget=new QTableWidget();


### PR DESCRIPTION
Propagates this to the localization files as well.