### PR TITLE
Support for Sequel Pro SQL dumps

### DIFF
--- a/src/file_txt.c
+++ b/src/file_txt.c
@@ -172,7 +172,7 @@ static const txt_header_t fasttxt_headers[] = {
   { "-- phpMyAdmin SQL Dump",				22, "sql"},
   { "--\n-- PostgreSQL database cluster dump",		38, "sql"},
   { "--\r\n-- PostgreSQL database cluster dump",	39, "sql"},
-  { "# Sequel Pro SQL dump",				21, "sql"},
+  { "# ************************************************************\n# Sequel Pro SQL dump", 84, "sql"},
   { "---- BEGIN SSH2 PUBLIC KEY ----",			31, "ppk"},
   { "PuTTY-User-Key-File-2:",				22, "ppk"},
   { "-----BEGIN PGP PRIVATE KEY BLOCK-----",		37, "priv"},

--- a/src/file_txt.c
+++ b/src/file_txt.c
@@ -172,6 +172,7 @@ static const txt_header_t fasttxt_headers[] = {
   { "-- phpMyAdmin SQL Dump",				22, "sql"},
   { "--\n-- PostgreSQL database cluster dump",		38, "sql"},
   { "--\r\n-- PostgreSQL database cluster dump",	39, "sql"},
+  { "# Sequel Pro SQL dump",				21, "sql"},
   { "---- BEGIN SSH2 PUBLIC KEY ----",			31, "ppk"},
   { "PuTTY-User-Key-File-2:",				22, "ppk"},
   { "-----BEGIN PGP PRIVATE KEY BLOCK-----",		37, "priv"},


### PR DESCRIPTION
SQL dumps from Sequel Pro start with:
```
# ************************************************************
# Sequel Pro SQL dump
# Version 4541
#
# http://www.sequelpro.com/
# https://github.com/sequelpro/sequelpro
#
# Host: 127.0.0.1 (MySQL 5.7.27-0ubuntu0.16.04.1)
# Database: db
# Generation Time: 2019-11-01 17:41:54 +0000
# ************************************************************
```