### PR TITLE
Add "report only" option

### DIFF
--- a/src/phcli.c
+++ b/src/phcli.c
@@ -174,6 +174,8 @@ int menu_photorec_cli(list_part_t *list_part, struct ph_param *params, struct ph
     else if(check_command(&params->cmd_run,"options",7)==0)
     {
       interface_options_photorec_cli(options, &params->cmd_run);
+      /* So we get it downstream in file_finish_*. */
+      params->report_only=options->report_only;
     }
     else if(check_command(&params->cmd_run,"fileopt",7)==0)
     {

--- a/src/phmain.c
+++ b/src/phmain.c
@@ -159,7 +159,8 @@ int main( int argc, char **argv )
     .expert=0,
     .lowmem=0,
     .verbose=0,
-    .list_file_format=array_file_enable
+    .list_file_format=array_file_enable,
+    .report_only=0
   };
   struct ph_param params;
   params.recup_dir=NULL;

--- a/src/phmain.c
+++ b/src/phmain.c
@@ -167,6 +167,7 @@ int main( int argc, char **argv )
   params.cmd_device=NULL;
   params.cmd_run=NULL;
   params.carve_free_space_only=0;
+  params.report_only=0;
   /* random (weak is ok) is need fot GPT */
   srand(time(NULL));
 #ifdef HAVE_SIGACTION

--- a/src/photorec.c
+++ b/src/photorec.c
@@ -569,18 +569,26 @@ static void file_finish_aux(file_recovery_t *file_recovery, struct ph_param *par
     return;
   }
 #if defined(HAVE_FTRUNCATE)
-  fflush(file_recovery->handle);
-  if(ftruncate(fileno(file_recovery->handle), file_recovery->file_size)<0)
+  if(!params->report_only)
   {
-    log_critical("ftruncate failed.\n");
+    fflush(file_recovery->handle);
+    if(ftruncate(fileno(file_recovery->handle), file_recovery->file_size)<0)
+    {
+      log_critical("ftruncate failed.\n");
+    }
   }
 #endif
   fclose(file_recovery->handle);
   file_recovery->handle=NULL;
-  if(file_recovery->time!=0 && file_recovery->time!=(time_t)-1)
-    set_date(file_recovery->filename, file_recovery->time, file_recovery->time);
-  if(file_recovery->file_rename!=NULL)
-    file_recovery->file_rename(file_recovery);
+  if(params->report_only)
+    unlink(file_recovery->filename);
+  else
+  {
+    if(file_recovery->time!=0 && file_recovery->time!=(time_t)-1)
+      set_date(file_recovery->filename, file_recovery->time, file_recovery->time);
+    if(file_recovery->file_rename!=NULL)
+      file_recovery->file_rename(file_recovery);
+  }
   if((++params->file_nbr)%MAX_FILES_PER_DIR==0)
   {
     params->dir_num=photorec_mkdir(params->recup_dir, params->dir_num+1);

--- a/src/photorec.h
+++ b/src/photorec.h
@@ -52,6 +52,7 @@ struct ph_param
   char *cmd_run;
   disk_t *disk;
   partition_t *partition;
+  int report_only;
   unsigned int carve_free_space_only;
   unsigned int blocksize;
   unsigned int pass;

--- a/src/photorec.h
+++ b/src/photorec.h
@@ -38,6 +38,7 @@ struct ph_options
 {
   int paranoid;
   int keep_corrupted_file;
+  int report_only;
   unsigned int mode_ext2;
   unsigned int expert;
   unsigned int lowmem;

--- a/src/phrecn.c
+++ b/src/phrecn.c
@@ -487,7 +487,7 @@ int photorec(struct ph_param *params, const struct ph_options *options, alloc_da
 #ifdef HAVE_NCURSES
 void interface_options_photorec_ncurses(struct ph_options *options)
 {
-  unsigned int menu = 5;
+  unsigned int menu = 6;
   struct MenuItem menuOptions[]=
   {
     { 'P', NULL, "Check JPG files" },
@@ -495,6 +495,7 @@ void interface_options_photorec_ncurses(struct ph_options *options)
     { 'S',NULL,"Try to skip indirect block"},
     { 'E',NULL,"Provide additional controls"},
     { 'L',NULL,"Low memory"},
+    { 'R',NULL,"Report only - don't recover files"},
     { 'Q',"Quit","Return to main menu"},
     { 0, NULL, NULL }
   };
@@ -518,8 +519,9 @@ void interface_options_photorec_ncurses(struct ph_options *options)
     menuOptions[2].name=options->mode_ext2?"ext2/ext3 mode: Yes":"ext2/ext3 mode : No";
     menuOptions[3].name=options->expert?"Expert mode : Yes":"Expert mode : No";
     menuOptions[4].name=options->lowmem?"Low memory: Yes":"Low memory: No";
+    menuOptions[5].name=options->report_only?"Report only - don't recover files: Yes":"Report only - don't recover files: No";
     aff_copy(stdscr);
-    car=wmenuSelect_ext(stdscr, 23, INTER_OPTION_Y, INTER_OPTION_X, menuOptions, 0, "PKELQ", MENU_VERT|MENU_VERT_ARROW2VALID, &menu,&real_key);
+    car=wmenuSelect_ext(stdscr, 23, INTER_OPTION_Y, INTER_OPTION_X, menuOptions, 0, "PKELRQ", MENU_VERT|MENU_VERT_ARROW2VALID, &menu,&real_key);
     switch(car)
     {
       case 'p':
@@ -544,6 +546,10 @@ void interface_options_photorec_ncurses(struct ph_options *options)
       case 'l':
       case 'L':
 	options->lowmem=!options->lowmem;
+	break;
+      case 'r':
+      case 'R':
+	options->report_only=!options->report_only;
 	break;
       case key_ESC:
       case 'q':

--- a/src/poptions.c
+++ b/src/poptions.c
@@ -78,6 +78,12 @@ void interface_options_photorec_cli(struct ph_options *options, char **current_c
     {
       options->lowmem=1;
     }
+    /* report_only */
+    else if(strncmp(*current_cmd,"report_only",11)==0)
+    {
+      (*current_cmd)+=11;
+      options->report_only=1;
+    }
     else
     {
       interface_options_photorec_log(options);
@@ -91,9 +97,10 @@ void interface_options_photorec_log(const struct ph_options *options)
   /* write new options to log file */
   log_info("New options :\n Paranoid : %s\n", options->paranoid?"Yes":"No");
   log_info(" Brute force : %s\n", ((options->paranoid)>1?"Yes":"No"));
-  log_info(" Keep corrupted files : %s\n ext2/ext3 mode : %s\n Expert mode : %s\n Low memory : %s\n",
+  log_info(" Keep corrupted files : %s\n ext2/ext3 mode : %s\n Expert mode : %s\n Low memory : %s\n Report only : %s\n",
       options->keep_corrupted_file?"Yes":"No",
       options->mode_ext2?"Yes":"No",
       options->expert?"Yes":"No",
-      options->lowmem?"Yes":"No");
+      options->lowmem?"Yes":"No",
+      options->report_only?"Yes":"No");
 }

--- a/src/ppartseln.c
+++ b/src/ppartseln.c
@@ -284,6 +284,8 @@ void menu_photorec(struct ph_param *params, struct ph_options *options, alloc_da
       case 'O':
 	{
 	  interface_options_photorec_ncurses(options);
+	  /* So we get it downstream in file_finish_*. */
+	  params->report_only=options->report_only;
 	  menu=1;
 	}
 	break;

--- a/src/qphotorec.cpp
+++ b/src/qphotorec.cpp
@@ -115,6 +115,7 @@ QPhotorec::QPhotorec(QWidget *my_parent) : QWidget(my_parent)
   options->mode_ext2=0;
   options->expert=0;
   options->lowmem=0;
+  options->report_only=0;
   options->verbose=0;
   options->list_file_format=array_file_enable;
   reset_array_file_enable(options->list_file_format);

--- a/src/sessionp.c
+++ b/src/sessionp.c
@@ -261,6 +261,8 @@ int session_save(alloc_data_t *list_free_space, struct ph_param *params,  const 
       fprintf(f_session, "expert,");
     if(options->lowmem>0)
       fprintf(f_session, "lowmem,");
+    if(options->report_only>0)
+      fprintf(f_session, "report_only,");
     /* Save options - End */
     if(params->carve_free_space_only>0)
       fprintf(f_session,"freespace,");


### PR DESCRIPTION
Fixes #17, replacing #21 .

I addressed some of the issues mentioned in the original PR; the main one, regarding the thumbnails, remains open - I'm not sure what is the right way to pass the flag down to `jpg_check_structure`. Adding it into `file_recovery_t` seems wrong and too invasive; the alternative being adding another argument, or passing `params` all the way down?

Since, for the time being, thumbnails are still being created, I didn't want to remove the line creating new directories, since they might be overcrowded by the thumbnails otherwise.