### PR TITLE
TestDisk: fix build without ncurses

### DIFF
--- a/src/adv.c
+++ b/src/adv.c
@@ -378,7 +378,7 @@ static void adv_menu_image_selected(disk_t *disk, const partition_t *partition, 
     ask_location(dst_path, sizeof(dst_path), msg, "");
   }
 #else
-  td_getcwd(&dst_path, sizeof(dst_path));
+  td_getcwd(dst_path, sizeof(dst_path));
 #endif
   if(dst_path[0]!='\0')
   {


### PR DESCRIPTION
Build was broken when TestDisk was configured to be built without ncurses

This happens when running `./configure --without-ncurses` and then `./compile.sh`
Fix verified working under Windows cygwin environment, now building TestDisk successfully