### PR TITLE
add support for gzipped scribus file

### DIFF
--- a/src/file_gz.c
+++ b/src/file_gz.c
@@ -358,6 +358,12 @@ static int header_check_gz(const unsigned char *buffer, const unsigned int buffe
       file_recovery_new->extension="schematic";
       return 1;
     }
+    if(memcmp(buffer_uncompr, "<SCRIBUS", 8) == 0)
+    {
+      /* Scribus XML file */
+      file_recovery_new->extension="sla.gz";
+      return 1;
+    }
     {
       unsigned int i;
       for(i=0; i<d_stream.total_out && i< 256; i++)


### PR DESCRIPTION
Scribus files can be gzipped..., so it seems to make sense to add this extension, ie. `.sla.gz`.

``` shell
$ zcat /tmp/Document-1.sla.gz | head -n2
<?xml version="1.0" encoding="UTF-8"?>
<SCRIBUSUTF8NEW Version="1.6.3">
```