### PR TITLE
Add `/maxsize <size>` parameter and photorec menu option to limit recovered file sizes

### DIFF
--- a/src/phmain.c
+++ b/src/phmain.c
@@ -123,7 +123,7 @@ static void sighup_hdlr(int sig)
 
 static void display_help(void)
 {
-  printf("\nUsage: photorec [/log] [/debug] [/d recup_dir] [/maxsize size] [file.dd|file.e01|device]\n"\
+  printf("\nUsage: photorec [/log] [/debug] [/maxsize size] [/d recup_dir] [file.dd|file.e01|device]\n"\
       "       photorec /version\n" \
       "\n" \
       "/log          : create a photorec.log file\n" \

--- a/src/photorec.c
+++ b/src/photorec.c
@@ -778,14 +778,20 @@ void file_recovery_aborted(file_recovery_t *file_recovery, struct ph_param *para
   reset_file_recovery(file_recovery);
 }
 
-pfstatus_t file_finish2(file_recovery_t *file_recovery, struct ph_param *params, const int paranoid, alloc_data_t *list_search_space)
+pfstatus_t file_finish2(file_recovery_t *file_recovery, struct ph_param *params, const struct ph_options *options, alloc_data_t *list_search_space)
 {
   int file_truncated;
   if(file_recovery->file_stat==NULL)
     return PFSTATUS_BAD;
   if(file_recovery->handle)
-    file_finish_aux(file_recovery, params, (paranoid==0?0:1));
+    file_finish_aux(file_recovery, params, (options->paranoid==0?0:1));
   if(file_recovery->file_size==0)
+  {
+    file_block_truncate_zero(file_recovery, list_search_space);
+    reset_file_recovery(file_recovery);
+    return PFSTATUS_BAD;
+  }
+  if(options->max_filesize > 0 && file_recovery->file_size > options->max_filesize)
   {
     file_block_truncate_zero(file_recovery, list_search_space);
     reset_file_recovery(file_recovery);

--- a/src/photorec.h
+++ b/src/photorec.h
@@ -22,6 +22,7 @@
 
 #ifndef _TESTDISK_PHOTOREC_H
 #define _TESTDISK_PHOTOREC_H
+#include "types.h"
 #define MAX_FILES_PER_DIR	500
 #define DEFAULT_RECUP_DIR "recup_dir"
 #ifdef __cplusplus
@@ -43,6 +44,7 @@ struct ph_options
   unsigned int lowmem;
   int verbose;
   file_enable_t *list_file_format;
+  uint64_t max_filesize;
 };
 
 struct ph_param
@@ -115,7 +117,7 @@ void file_recovery_aborted(file_recovery_t *file_recovery, struct ph_param *para
   @ ensures  \result == PFSTATUS_BAD || \result == PFSTATUS_OK || \result == PFSTATUS_OK_TRUNCATED;
   @*/
 // ensures  valid_file_recovery(file_recovery);
-pfstatus_t file_finish2(file_recovery_t *file_recovery, struct ph_param *params, const int paranoid, alloc_data_t *list_search_space);
+pfstatus_t file_finish2(file_recovery_t *file_recovery, struct ph_param *params, const struct ph_options *options, alloc_data_t *list_search_space);
 
 /*@
   @ requires \valid_read(file_stats);

--- a/src/photorec_check_header.h
+++ b/src/photorec_check_header.h
@@ -110,7 +110,7 @@ static pstatus_t photorec_header_found(const file_recovery_t *file_recovery_new,
     if(options->verbose > 1)
       log_trace("A known header has been found, recovery of the previous file is finished\n");
 #endif
-    *file_recovered=file_finish2(file_recovery, params, options->paranoid, list_search_space);
+    *file_recovered=file_finish2(file_recovery, params, options, list_search_space);
     if(*file_recovered==PFSTATUS_OK_TRUNCATED)
       return PSTATUS_OK;
   }

--- a/src/poptions.c
+++ b/src/poptions.c
@@ -87,6 +87,11 @@ void interface_options_photorec_cli(struct ph_options *options, char **current_c
     {
       options->lowmem=1;
     }
+    /* maxfile */
+    else if(check_command(current_cmd,"maxfile,",8)==0)
+    {
+      options->max_filesize=get_int_from_command(current_cmd);
+    }
     else
     {
 #ifndef DISABLED_FOR_FRAMAC

--- a/src/psearchn.c
+++ b/src/psearchn.c
@@ -204,14 +204,25 @@ pstatus_t photorec_aux(struct ph_param *params, const struct ph_options *options
 	}
 	if(ind_stop==PSTATUS_OK)
 	{
-	  /*@ assert valid_file_recovery(&file_recovery); */
-	  file_block_append(&file_recovery, list_search_space, &current_search_space, &offset, blocksize, 1);
-	  /*@ assert valid_file_recovery(&file_recovery); */
-	  if(file_recovery.data_check!=NULL)
-	    data_check_status=file_recovery.data_check(buffer_olddata,2*blocksize,&file_recovery);
+	  if(options->max_filesize > 0 && file_recovery.file_size + blocksize > options->max_filesize)
+	  {
+	    data_check_status=DC_STOP;
+#ifndef DISABLED_FOR_FRAMAC
+	    log_verbose("File should not be bigger than %llu, stop adding data\n",
+		(long long unsigned)options->max_filesize);
+#endif
+	  }
 	  else
-	    data_check_status=DC_CONTINUE;
-	  file_recovery.file_size+=blocksize;
+	  {
+	    /*@ assert valid_file_recovery(&file_recovery); */
+	    file_block_append(&file_recovery, list_search_space, &current_search_space, &offset, blocksize, 1);
+	    /*@ assert valid_file_recovery(&file_recovery); */
+	    if(file_recovery.data_check!=NULL)
+	      data_check_status=file_recovery.data_check(buffer_olddata,2*blocksize,&file_recovery);
+	    else
+	      data_check_status=DC_CONTINUE;
+	    file_recovery.file_size+=blocksize;
+	  }
 #ifndef DISABLED_FOR_FRAMAC
 	  if(data_check_status==DC_STOP)
 	  {
@@ -225,7 +236,7 @@ pstatus_t photorec_aux(struct ph_param *params, const struct ph_options *options
       {
 	data_check_status=DC_STOP;
 #ifndef DISABLED_FOR_FRAMAC
-	log_verbose("File should not be bigger than %llu, stopped adding data\n",
+	log_verbose("File should not be bigger than %llu, stop adding data\n",
 	    (long long unsigned)file_recovery.file_stat->file_hint->max_filesize);
 #endif
       }
@@ -233,7 +244,7 @@ pstatus_t photorec_aux(struct ph_param *params, const struct ph_options *options
       {
 	data_check_status=DC_STOP;
 #ifndef DISABLED_FOR_FRAMAC
-	log_verbose("File should not be bigger than %llu, stopped adding data\n",
+	log_verbose("File should not be bigger than %llu, stop adding data\n",
 	    (long long unsigned)file_recovery.file_stat->file_hint->max_filesize);
 #endif
       }
@@ -241,7 +252,7 @@ pstatus_t photorec_aux(struct ph_param *params, const struct ph_options *options
       {
 	if(data_check_status==DC_ERROR)
 	  file_recovery.file_size=0;
-	file_recovered=file_finish2(&file_recovery, params, options->paranoid, list_search_space);
+	file_recovered=file_finish2(&file_recovery, params, options, list_search_space);
 	if(options->lowmem > 0)
 	  forget(list_search_space,current_search_space);
       }
@@ -307,7 +318,7 @@ pstatus_t photorec_aux(struct ph_param *params, const struct ph_options *options
 	  current_search_space, current_search_space->list.prev, current_search_space->list.next);
       log_trace("End of media\n");
 #endif
-      file_recovered=file_finish2(&file_recovery, params, options->paranoid, list_search_space);
+      file_recovered=file_finish2(&file_recovery, params, options, list_search_space);
       if(file_recovered!=PFSTATUS_BAD)
 	get_prev_location_smart(list_search_space, &current_search_space, &offset, file_recovery.location.start);
       if(options->lowmem > 0)

--- a/src/sessionp.c
+++ b/src/sessionp.c
@@ -299,6 +299,8 @@ int session_save(const alloc_data_t *list_free_space, const struct ph_param *par
       fprintf(f_session, "expert,");
     if(options->lowmem>0)
       fprintf(f_session, "lowmem,");
+    if(options->max_filesize>0)
+      fprintf(f_session, "maxfile,%llu,", (unsigned long long)options->max_filesize);
     /* Save options - End */
     if(params->carve_free_space_only>0)
       fprintf(f_session,"freespace,");


### PR DESCRIPTION
Adds /maxsize <size> parameter to limit recovered files sizes.

  - /maxsize <size> parameter with K/M/G/T units (e.g. /maxsize 500M)
  - ncurses 'M' menu option for interactive setting
  - Takes precedence over per-file-type limits
  - Backward compatible (uses existing per-file-type limits by default)
  - Size checking before data writing to avoid unnecessary disk I/O and memory allocation
  - Final validation in file_finish2() as last line of defense
  - Unit parsing with powers of 1024 (1K = 1024 bytes)