### PR TITLE
fix ncurses termination handling

### DIFF
--- a/src/phmain.c
+++ b/src/phmain.c
@@ -100,9 +100,15 @@ extern uint64_t gpls_nbr;
 #ifdef HAVE_SIGACTION
 static struct sigaction action;
 static void sighup_hdlr(int sig);
+#ifdef HAVE_NCURSES
+extern int end_ncurses(void);
+#endif
 
 static void sighup_hdlr(int sig)
 {
+#ifdef HAVE_NCURSES
+  end_ncurses();
+#endif
   if(sig == SIGINT)
     log_critical("SIGINT detected! PhotoRec has been killed.\n");
   else if(sig == SIGHUP)

--- a/src/testdisk.c
+++ b/src/testdisk.c
@@ -79,6 +79,9 @@ static struct sigaction action;
 
 static void sighup_hdlr(int sig)
 {
+#ifdef HAVE_NCURSES
+  end_ncurses();
+#endif
   if(sig == SIGINT)
     log_critical("SIGINT detected! PhotoRec has been killed.\n");
   else if(sig == SIGHUP)


### PR DESCRIPTION
PhotoRec often corrupted the terminal when killed with Ctrl+C in ncurses mode. Users had to run reset or stty sane to restore normal terminal functionality after interrupting the program. This PR fixes that.