### PR TITLE
QPhotoRec: Add search filter to File Formats dialog

### DIFF
--- a/src/lang/qphotorec.ca.ts
+++ b/src/lang/qphotorec.ca.ts
@@ -257,11 +257,16 @@ Hauríeu d&apos;haver rebut una còpia de la Llicència Pública General GNU jun
     </message>
     <message>
         <location filename="src/qphotorec.cpp" line="960"/>
+        <source>Search formats</source>
+        <translation>Cerca formats</translation>
+    </message>
+    <message>
+        <location filename="src/qphotorec.cpp" line="965"/>
         <source>&amp;Reset</source>
         <translation>&amp;Reinicialitzar</translation>
     </message>
     <message>
-        <location filename="src/qphotorec.cpp" line="961"/>
+        <location filename="src/qphotorec.cpp" line="966"/>
         <source>Res&amp;tore</source>
         <translation>
 Res&amp;taura</translation>

--- a/src/lang/qphotorec.cs.ts
+++ b/src/lang/qphotorec.cs.ts
@@ -256,11 +256,16 @@ Společně s QPhotoRec byste měli obdržet text znění GNU General Public Lice
     </message>
     <message>
         <location filename="src/qphotorec.cpp" line="960"/>
+        <source>Search formats</source>
+        <translation>Hledat formáty</translation>
+    </message>
+    <message>
+        <location filename="src/qphotorec.cpp" line="965"/>
         <source>&amp;Reset</source>
         <translation>V&amp;rátit na výchozí</translation>
     </message>
     <message>
-        <location filename="src/qphotorec.cpp" line="961"/>
+        <location filename="src/qphotorec.cpp" line="966"/>
         <source>Res&amp;tore</source>
         <translation>Obnovi&amp;t</translation>
     </message>

--- a/src/lang/qphotorec.el.ts
+++ b/src/lang/qphotorec.el.ts
@@ -257,11 +257,16 @@ You should have received a copy of the GNU General Public License along with QPh
     </message>
     <message>
         <location filename="src/qphotorec.cpp" line="960"/>
+        <source>Search formats</source>
+        <translation>Αναζήτηση μορφών</translation>
+    </message>
+    <message>
+        <location filename="src/qphotorec.cpp" line="965"/>
         <source>&amp;Reset</source>
         <translation>&amp;Επαναφορά</translation>
     </message>
     <message>
-        <location filename="src/qphotorec.cpp" line="961"/>
+        <location filename="src/qphotorec.cpp" line="966"/>
         <source>Res&amp;tore</source>
         <translation>Ανά&amp;κτηση</translation>
     </message>

--- a/src/lang/qphotorec.es.ts
+++ b/src/lang/qphotorec.es.ts
@@ -257,11 +257,16 @@ Debería haber recibido una copia de la Licencia Pública General de GNU junto c
     </message>
     <message>
         <location filename="src/qphotorec.cpp" line="960"/>
+        <source>Search formats</source>
+        <translation>Buscar formatos</translation>
+    </message>
+    <message>
+        <location filename="src/qphotorec.cpp" line="965"/>
         <source>&amp;Reset</source>
         <translation>&amp;Reiniciar</translation>
     </message>
     <message>
-        <location filename="src/qphotorec.cpp" line="961"/>
+        <location filename="src/qphotorec.cpp" line="966"/>
         <source>Res&amp;tore</source>
         <translation>Res&amp;tore</translation>
     </message>

--- a/src/lang/qphotorec.fi.ts
+++ b/src/lang/qphotorec.fi.ts
@@ -257,11 +257,16 @@ QPhotoRec:in mukana tulisi olla sinulle toimitettuna tuo GNU-yleisluvan selontek
     </message>
     <message>
         <location filename="src/qphotorec.cpp" line="960"/>
+        <source>Search formats</source>
+        <translation>Etsi formaatteja</translation>
+    </message>
+    <message>
+        <location filename="src/qphotorec.cpp" line="965"/>
         <source>&amp;Reset</source>
         <translation>&amp;Nollaa</translation>
     </message>
     <message>
-        <location filename="src/qphotorec.cpp" line="961"/>
+        <location filename="src/qphotorec.cpp" line="966"/>
         <source>Res&amp;tore</source>
         <translation>Palau&amp;ta</translation>
     </message>

--- a/src/lang/qphotorec.fr.ts
+++ b/src/lang/qphotorec.fr.ts
@@ -256,11 +256,16 @@ Vous avez du recevoir un exemplaire de la Licence Publique Générale GNU avec c
     </message>
     <message>
         <location filename="src/qphotorec.cpp" line="960"/>
+        <source>Search formats</source>
+        <translation>Rechercher des formats</translation>
+    </message>
+    <message>
+        <location filename="src/qphotorec.cpp" line="965"/>
         <source>&amp;Reset</source>
         <translation>&amp;Réinitialiser</translation>
     </message>
     <message>
-        <location filename="src/qphotorec.cpp" line="961"/>
+        <location filename="src/qphotorec.cpp" line="966"/>
         <source>Res&amp;tore</source>
         <translation>Res&amp;taurer</translation>
     </message>

--- a/src/lang/qphotorec.it.ts
+++ b/src/lang/qphotorec.it.ts
@@ -258,11 +258,16 @@ Una copia della GNU General Public License è distribuita con QPhotoRec. In caso
     </message>
     <message>
         <location filename="src/qphotorec.cpp" line="960"/>
+        <source>Search formats</source>
+        <translation>Cerca formati</translation>
+    </message>
+    <message>
+        <location filename="src/qphotorec.cpp" line="965"/>
         <source>&amp;Reset</source>
         <translation>&amp;Resettare</translation>
     </message>
     <message>
-        <location filename="src/qphotorec.cpp" line="961"/>
+        <location filename="src/qphotorec.cpp" line="966"/>
         <source>Res&amp;tore</source>
         <translation>Ripri&amp;stinare</translation>
     </message>

--- a/src/lang/qphotorec.ja.ts
+++ b/src/lang/qphotorec.ja.ts
@@ -252,11 +252,16 @@ You should have received a copy of the GNU General Public License along with QPh
     </message>
     <message>
         <location filename="src/qphotorec.cpp" line="960"/>
+        <source>Search formats</source>
+        <translation>フォーマットを検索</translation>
+    </message>
+    <message>
+        <location filename="src/qphotorec.cpp" line="965"/>
         <source>&amp;Reset</source>
         <translation>&amp;リセット</translation>
     </message>
     <message>
-        <location filename="src/qphotorec.cpp" line="961"/>
+        <location filename="src/qphotorec.cpp" line="966"/>
         <source>Res&amp;tore</source>
         <translation type="unfinished"/>
     </message>

--- a/src/lang/qphotorec.pl.ts
+++ b/src/lang/qphotorec.pl.ts
@@ -258,11 +258,16 @@ Powinieneś otrzymać kopię licencji GNU General Public License wraz z QPhotoRe
     </message>
     <message>
         <location filename="src/qphotorec.cpp" line="960"/>
+        <source>Search formats</source>
+        <translation>Szukaj formatów</translation>
+    </message>
+    <message>
+        <location filename="src/qphotorec.cpp" line="965"/>
         <source>&amp;Reset</source>
         <translation>&amp;Resetuj</translation>
     </message>
     <message>
-        <location filename="src/qphotorec.cpp" line="961"/>
+        <location filename="src/qphotorec.cpp" line="966"/>
         <source>Res&amp;tore</source>
         <translation>Pr&amp;zywróć</translation>
     </message>

--- a/src/lang/qphotorec.pt.ts
+++ b/src/lang/qphotorec.pt.ts
@@ -257,11 +257,16 @@ Você deve receber uma cópia do licença GNU durante o uso de QPhotoRec. Se nã
     </message>
     <message>
         <location filename="src/qphotorec.cpp" line="960"/>
+        <source>Search formats</source>
+        <translation>Pesquisar formatos</translation>
+    </message>
+    <message>
+        <location filename="src/qphotorec.cpp" line="965"/>
         <source>&amp;Reset</source>
         <translation>&amp;Reconfigurar</translation>
     </message>
     <message>
-        <location filename="src/qphotorec.cpp" line="961"/>
+        <location filename="src/qphotorec.cpp" line="966"/>
         <source>Res&amp;tore</source>
         <translation>&amp;Restaurar</translation>
     </message>

--- a/src/lang/qphotorec.ru.ts
+++ b/src/lang/qphotorec.ru.ts
@@ -257,11 +257,16 @@ PhotoRec распространяется в надежде, что она бу�
     </message>
     <message>
         <location filename="src/qphotorec.cpp" line="960"/>
+        <source>Search formats</source>
+        <translation>Поиск форматов</translation>
+    </message>
+    <message>
+        <location filename="src/qphotorec.cpp" line="965"/>
         <source>&amp;Reset</source>
         <translation>Сб&amp;росить</translation>
     </message>
     <message>
-        <location filename="src/qphotorec.cpp" line="961"/>
+        <location filename="src/qphotorec.cpp" line="966"/>
         <source>Res&amp;tore</source>
         <translation>&amp;Вернуть</translation>
     </message>

--- a/src/lang/qphotorec.sv_SE.ts
+++ b/src/lang/qphotorec.sv_SE.ts
@@ -248,11 +248,16 @@ You should have received a copy of the GNU General Public License along with QPh
     </message>
     <message>
         <location filename="src/qphotorec.cpp" line="960"/>
+        <source>Search formats</source>
+        <translation>Sök format</translation>
+    </message>
+    <message>
+        <location filename="src/qphotorec.cpp" line="965"/>
         <source>&amp;Reset</source>
         <translation>&amp;Rensa</translation>
     </message>
     <message>
-        <location filename="src/qphotorec.cpp" line="961"/>
+        <location filename="src/qphotorec.cpp" line="966"/>
         <source>Res&amp;tore</source>
         <translation>Åter%ställ</translation>
     </message>

--- a/src/lang/qphotorec.tr.ts
+++ b/src/lang/qphotorec.tr.ts
@@ -257,11 +257,16 @@ QPhotoRec ile birlikte GNU Genel Kamu Lisansı&apos;nın bir kopyasını almış
     </message>
     <message>
         <location filename="src/qphotorec.cpp" line="960"/>
+        <source>Search formats</source>
+        <translation>Formatları ara</translation>
+    </message>
+    <message>
+        <location filename="src/qphotorec.cpp" line="965"/>
         <source>&amp;Reset</source>
         <translation>&amp;Hiçbiri</translation>
     </message>
     <message>
-        <location filename="src/qphotorec.cpp" line="961"/>
+        <location filename="src/qphotorec.cpp" line="966"/>
         <source>Res&amp;tore</source>
         <translation>&amp;Tümü</translation>
     </message>

--- a/src/lang/qphotorec.zh_CN.ts
+++ b/src/lang/qphotorec.zh_CN.ts
@@ -257,11 +257,16 @@ You should have received a copy of the GNU General Public License along with QPh
     </message>
     <message>
         <location filename="src/qphotorec.cpp" line="960"/>
+        <source>Search formats</source>
+        <translation>搜索格式</translation>
+    </message>
+    <message>
+        <location filename="src/qphotorec.cpp" line="965"/>
         <source>&amp;Reset</source>
         <translation>重置(&amp;R)</translation>
     </message>
     <message>
-        <location filename="src/qphotorec.cpp" line="961"/>
+        <location filename="src/qphotorec.cpp" line="966"/>
         <source>Res&amp;tore</source>
         <translation>恢复(&amp;T)</translation>
     </message>

--- a/src/lang/qphotorec.zh_TW.ts
+++ b/src/lang/qphotorec.zh_TW.ts
@@ -257,11 +257,16 @@ You should have received a copy of the GNU General Public License along with QPh
     </message>
     <message>
         <location filename="src/qphotorec.cpp" line="960"/>
+        <source>Search formats</source>
+        <translation>搜尋格式</translation>
+    </message>
+    <message>
+        <location filename="src/qphotorec.cpp" line="965"/>
         <source>&amp;Reset</source>
         <translation>重設(&amp;R)</translation>
     </message>
     <message>
-        <location filename="src/qphotorec.cpp" line="961"/>
+        <location filename="src/qphotorec.cpp" line="966"/>
         <source>Res&amp;tore</source>
         <translation>還原(&amp;T)</translation>
     </message>

--- a/src/qphotorec.cpp
+++ b/src/qphotorec.cpp
@@ -955,6 +955,11 @@ void QPhotorec::qphotorec_formats()
 
   QDialog fenetre3;
   fenetre3.setWindowTitle("QPhotoRec: "+tr("File Formats"));
+
+  QLineEdit *ed_search = new QLineEdit();
+  ed_search->setPlaceholderText("Search formats");
+  ed_search->setClearButtonEnabled(true);
+
   QDialogButtonBox buttonBox(Qt::Horizontal);
 
   QPushButton *bt_reset= new QPushButton(tr("&Reset"));
@@ -963,14 +968,18 @@ void QPhotorec::qphotorec_formats()
   buttonBox.addButton(bt_reset, QDialogButtonBox::ResetRole);
   buttonBox.addButton(bt_restore, QDialogButtonBox::ResetRole);
   buttonBox.addButton(QDialogButtonBox::Ok);
+
   QVBoxLayout vbox;
+  vbox.addWidget(ed_search);
   vbox.addWidget(formats);
   vbox.addWidget(&buttonBox);
   fenetre3.setLayout(&vbox);
+  connect(ed_search, SIGNAL(textChanged(QString)), this, SLOT(formats_search(QString)));
   connect(&buttonBox, SIGNAL(accepted()), &fenetre3, SLOT(accept()));
   connect(bt_reset, SIGNAL(clicked()), this, SLOT(formats_reset()));
   connect(bt_restore, SIGNAL(clicked()), this, SLOT(formats_restore()));
   fenetre3.exec();
+
   int i;
   for (i = 0, file_enable=array_file_enable;
       i < formats->count() && file_enable->file_hint!=NULL;
@@ -1002,5 +1011,20 @@ void QPhotorec::formats_restore()
       item->setCheckState (Qt::Checked);
     else
       item->setCheckState (Qt::Unchecked);
+  }
+}
+
+void QPhotorec::formats_search(const QString &format)
+{
+  file_enable_t *file_enable;
+  int i;
+  for (i = 0, file_enable=array_file_enable;
+      i < formats->count() && file_enable->file_hint!=NULL;
+      i++, file_enable++)
+  {
+    QListWidgetItem *item = formats->item(i);
+    QString descr = item->text();
+    bool hide = descr.contains(format, Qt::CaseInsensitive)?false:true;
+    item->setHidden(hide);
   }
 }

--- a/src/qphotorec.cpp
+++ b/src/qphotorec.cpp
@@ -957,7 +957,7 @@ void QPhotorec::qphotorec_formats()
   fenetre3.setWindowTitle("QPhotoRec: "+tr("File Formats"));
 
   QLineEdit *ed_search = new QLineEdit();
-  ed_search->setPlaceholderText("Search formats");
+  ed_search->setPlaceholderText(tr("Search formats"));
   ed_search->setClearButtonEnabled(true);
 
   QDialogButtonBox buttonBox(Qt::Horizontal);

--- a/src/qphotorec.h
+++ b/src/qphotorec.h
@@ -52,6 +52,7 @@ class QPhotorec: public QWidget
 		/* Formats */
 		void formats_reset();
 		void formats_restore();
+		void formats_search(const QString &format);
 	protected:
                 void setupUI();
 		void clearWidgets();


### PR DESCRIPTION
**Added a search bar to the File Formats dialog to:**

- Simplify search: Users can find specific formats without scrolling through the entire list.
- Save time: Real-time filtering by extension or description (e.g., "Video").

**Localization:**

- Added translations for the new search interface.
 
**Visuals:**

<img width="280" height="307" alt="formats-filter-default" src="https://github.com/user-attachments/assets/74617e18-1630-4f95-a11a-93aa84f2a7a3" />
<img width="280" height="307" alt="formats-filter" src="https://github.com/user-attachments/assets/87b14dc3-f078-4161-a627-104dae074d2c" />
