### PR TITLE
Add PhotoRec image minimum filters

### DIFF
--- a/man/photorec.8.in
+++ b/man/photorec.8.in
@@ -16,6 +16,9 @@ create a photorec.log file
 .TP
 .B /debug
 add debug information
+.TP
+.BI "/cmd device options,image_min_width,n,image_min_height,n,image_min_pixels,n,image_min_filesize,n,search"
+recover files from a device or image with optional JPEG/PNG minimum image filters. Width and height are in pixels, pixels is width multiplied by height, and filesize is in bytes.
 .SH SEE ALSO
 .BR testdisk (8),
 .BR fdisk (8).

--- a/src/file_jpg.c
+++ b/src/file_jpg.c
@@ -93,6 +93,14 @@ const file_hint_t file_hint_jpg= {
   .register_header_check=&register_header_check_jpg
 };
 
+static int jpg_marker_is_sof(const unsigned char marker)
+{
+  return marker==0xc0 || marker==0xc1 || marker==0xc2 || marker==0xc3 ||
+    marker==0xc5 || marker==0xc6 || marker==0xc7 ||
+    marker==0xc9 || marker==0xca || marker==0xcb ||
+    marker==0xcd || marker==0xce || marker==0xcf;
+}
+
 /*@
   @ requires PHOTOREC_MAX_BLOCKSIZE >= buffer_size;
   @ requires \valid_read(buffer + (0 .. buffer_size-1));
@@ -120,7 +128,7 @@ static void jpg_get_size(const unsigned char *buffer, const unsigned int buffer_
       /*@ assert 0 <= ((buffer[i+2]<<8) | buffer[i+3]) <= 0xffff; */
       const unsigned int size=((unsigned int)buffer[i+2]<<8)|buffer[i+3];
       /*@ assert size <= 0xffff; */
-      if(buffer[i+1]==0xc0)	/* SOF0 */
+      if(jpg_marker_is_sof(buffer[i+1])!=0)
       {
 	/*@ assert 0<= (buffer[i+5]<<8) <= 0xff00; */
 	/*@ assert 0 <= ((buffer[i+5]<<8) | buffer[i+6]) <= 0xffff; */
@@ -137,6 +145,33 @@ static void jpg_get_size(const unsigned char *buffer, const unsigned int buffer_
       return;
     }
   }
+}
+
+static void file_check_jpg_min_dimensions(file_recovery_t *file_recovery)
+{
+  unsigned int buffer_size;
+  size_t read_size;
+  unsigned char *buffer;
+  unsigned int width=0;
+  unsigned int height=0;
+  if(photorec_image_min_dimension_filter_enabled()==0 ||
+      file_recovery->file_size==0 ||
+      file_recovery->handle==NULL)
+    return;
+  buffer_size=(file_recovery->file_size < 262144 ? (unsigned int)file_recovery->file_size : 262144);
+  if(buffer_size < 16)
+    return;
+  buffer=(unsigned char *)MALLOC(buffer_size);
+  if(my_fseek(file_recovery->handle, 0, SEEK_SET) < 0)
+  {
+    free(buffer);
+    return;
+  }
+  read_size=fread(buffer, 1, buffer_size, file_recovery->handle);
+  jpg_get_size(buffer, (unsigned int)read_size, &height, &width);
+  free(buffer);
+  if(photorec_image_min_dimensions_reject(file_hint_jpg.extension, width, height)!=0)
+    file_recovery->file_size=0;
 }
 
 struct MP_IFD_Field
@@ -1046,8 +1081,18 @@ static int header_check_jpg(const unsigned char *buffer, const unsigned int buff
 	return 0;
     }
   }
+  if(photorec_image_min_dimension_filter_enabled()!=0)
+  {
+    unsigned int width=0;
+    unsigned int height=0;
+    jpg_get_size(buffer, buffer_size, &height, &width);
+    if(photorec_image_min_dimensions_reject(file_hint_jpg.extension, width, height)!=0)
+      return 0;
+  }
   reset_file_recovery(file_recovery_new);
   file_recovery_new->min_filesize=i;
+  if(file_recovery_new->min_filesize < photorec_image_min_filesize())
+    file_recovery_new->min_filesize=photorec_image_min_filesize();
   file_recovery_new->calculated_file_size=0;
   file_recovery_new->time=jpg_time;
   file_recovery_new->extension=file_hint_jpg.extension;
@@ -2494,6 +2539,7 @@ static void file_check_jpg(file_recovery_t *file_recovery)
 #else
   file_recovery->file_size=file_recovery->calculated_file_size;
 #endif
+  file_check_jpg_min_dimensions(file_recovery);
 #if 0
     /* FIXME REMOVE ME */
   if(file_recovery->offset_error!=0)

--- a/src/file_png.c
+++ b/src/file_png.c
@@ -330,6 +330,12 @@ static int header_check_png(const unsigned char *buffer, const unsigned int buff
   if(memcmp(&buffer[8+4], "IHDR", 4) == 0 &&
       png_check_ihdr((const struct png_ihdr *)&buffer[16])==0)
     return 0;
+  if(memcmp(&buffer[8+4], "IHDR", 4) == 0)
+  {
+    const struct png_ihdr *ihdr=(const struct png_ihdr *)&buffer[16];
+    if(photorec_image_min_dimensions_reject(file_hint_png.extension, be32(ihdr->width), be32(ihdr->height))!=0)
+      return 0;
+  }
 #if !defined(SINGLE_FORMAT)
   /* SolidWorks files contain a png */
   if(file_recovery->file_stat!=NULL &&
@@ -342,6 +348,8 @@ static int header_check_png(const unsigned char *buffer, const unsigned int buff
   reset_file_recovery(file_recovery_new);
   file_recovery_new->extension=file_hint_png.extension;
   file_recovery_new->min_filesize=16;
+  if(file_recovery_new->min_filesize < photorec_image_min_filesize())
+    file_recovery_new->min_filesize=photorec_image_min_filesize();
   if(file_recovery_new->blocksize < 8)
   {
     /*@ assert valid_file_recovery(file_recovery_new); */

--- a/src/filegen.c
+++ b/src/filegen.c
@@ -47,6 +47,76 @@
 #include "log.h"
 
 static int file_check_cmp(const struct td_list_head *a, const struct td_list_head *b);
+static photorec_image_min_filter_t photorec_image_min_filter={
+  .min_filesize=0,
+  .min_width=0,
+  .min_height=0,
+  .min_pixels=0
+};
+
+void photorec_set_image_min_filter(const photorec_image_min_filter_t *filter)
+{
+  if(filter==NULL)
+  {
+    photorec_image_min_filter.min_filesize=0;
+    photorec_image_min_filter.min_width=0;
+    photorec_image_min_filter.min_height=0;
+    photorec_image_min_filter.min_pixels=0;
+    return;
+  }
+  photorec_image_min_filter=*filter;
+}
+
+uint64_t photorec_image_min_filesize(void)
+{
+  return photorec_image_min_filter.min_filesize;
+}
+
+int photorec_image_min_dimension_filter_enabled(void)
+{
+  return photorec_image_min_filter.min_width!=0 ||
+    photorec_image_min_filter.min_height!=0 ||
+    photorec_image_min_filter.min_pixels!=0;
+}
+
+int photorec_image_min_dimensions_reject(const char *extension, const uint64_t width, const uint64_t height)
+{
+  uint64_t pixels;
+  if(width==0 || height==0)
+    return 0;
+  if(photorec_image_min_filter.min_width!=0 &&
+      width < photorec_image_min_filter.min_width)
+  {
+    log_info("%s image too narrow (%llu < %u), reject it\n",
+	(extension!=NULL?extension:"image"),
+	(long long unsigned)width,
+	photorec_image_min_filter.min_width);
+    return 1;
+  }
+  if(photorec_image_min_filter.min_height!=0 &&
+      height < photorec_image_min_filter.min_height)
+  {
+    log_info("%s image too short (%llu < %u), reject it\n",
+	(extension!=NULL?extension:"image"),
+	(long long unsigned)height,
+	photorec_image_min_filter.min_height);
+    return 1;
+  }
+  if(height!=0 && width > UINT64_MAX / height)
+    pixels=UINT64_MAX;
+  else
+    pixels=width * height;
+  if(photorec_image_min_filter.min_pixels!=0 &&
+      pixels < photorec_image_min_filter.min_pixels)
+  {
+    log_info("%s image has too few pixels (%llu < %llu), reject it\n",
+	(extension!=NULL?extension:"image"),
+	(long long unsigned)pixels,
+	(long long unsigned)photorec_image_min_filter.min_pixels);
+    return 1;
+  }
+  return 0;
+}
 
 #ifndef __FRAMAC__
 #include "list_add_sorted.h"

--- a/src/filegen.h
+++ b/src/filegen.h
@@ -48,6 +48,14 @@ typedef struct file_stat_struct file_stat_t;
 typedef struct file_recovery_struct file_recovery_t;
 typedef struct file_enable_struct file_enable_t;
 
+typedef struct
+{
+  uint64_t min_filesize;
+  unsigned int min_width;
+  unsigned int min_height;
+  uint64_t min_pixels;
+} photorec_image_min_filter_t;
+
 struct file_hint_struct
 {
   const char *extension;
@@ -475,6 +483,11 @@ time_t get_time_from_YYYYMMDD_HHMMSS(const char *date_asc);
   @ requires \separated(list_search_space, current_search_space, offset);
   @*/
 void get_prev_location_smart(const alloc_data_t *list_search_space, alloc_data_t **current_search_space, uint64_t *offset, const uint64_t prev_location);
+
+void photorec_set_image_min_filter(const photorec_image_min_filter_t *filter);
+uint64_t photorec_image_min_filesize(void);
+int photorec_image_min_dimension_filter_enabled(void);
+int photorec_image_min_dimensions_reject(const char *extension, const uint64_t width, const uint64_t height);
 
 #ifdef __cplusplus
 } /* closing brace for extern "C" */

--- a/src/phmain.c
+++ b/src/phmain.c
@@ -185,6 +185,10 @@ int main( int argc, char **argv )
     .mode_ext2=0,
     .expert=0,
     .lowmem=0,
+    .image_min_filesize=0,
+    .image_min_width=0,
+    .image_min_height=0,
+    .image_min_pixels=0,
     .verbose=0,
     .list_file_format=array_file_enable
   };

--- a/src/photorec.c
+++ b/src/photorec.c
@@ -963,7 +963,14 @@ static void params_reset_aux(struct ph_param *params)
 
 void params_reset(struct ph_param *params, const struct ph_options *options)
 {
+  const photorec_image_min_filter_t image_min_filter={
+    .min_filesize=options->image_min_filesize,
+    .min_width=options->image_min_width,
+    .min_height=options->image_min_height,
+    .min_pixels=options->image_min_pixels
+  };
   /*@ assert valid_ph_param(params); */
+  photorec_set_image_min_filter(&image_min_filter);
   params->file_stats=init_file_stats(options->list_file_format);
   /*@ assert valid_ph_param(params); */
   params_reset_aux(params);

--- a/src/photorec.h
+++ b/src/photorec.h
@@ -41,6 +41,10 @@ struct ph_options
   unsigned int mode_ext2;
   unsigned int expert;
   unsigned int lowmem;
+  uint64_t image_min_filesize;
+  unsigned int image_min_width;
+  unsigned int image_min_height;
+  uint64_t image_min_pixels;
   int verbose;
   file_enable_t *list_file_format;
 };

--- a/src/phrecn.c
+++ b/src/phrecn.c
@@ -504,7 +504,11 @@ int photorec(struct ph_param *params, const struct ph_options *options, alloc_da
 #ifdef HAVE_NCURSES
 void interface_options_photorec_ncurses(struct ph_options *options)
 {
-  unsigned int menu = 5;
+  unsigned int menu = 9;
+  char options_msg[80];
+  char options_msg2[80];
+  char options_msg3[80];
+  char options_msg4[80];
   struct MenuItem menuOptions[]=
   {
     { 'P', NULL, "Check JPG files" },
@@ -512,6 +516,10 @@ void interface_options_photorec_ncurses(struct ph_options *options)
     { 'S',NULL,"Try to skip indirect block"},
     { 'E',NULL,"Provide additional controls"},
     { 'L',NULL,"Low memory"},
+    { 'B',NULL,"Minimum image file size"},
+    { 'W',NULL,"Minimum image width"},
+    { 'H',NULL,"Minimum image height"},
+    { 'A',NULL,"Minimum image area"},
     { 'Q',"Quit","Return to main menu"},
     { 0, NULL, NULL }
   };
@@ -535,8 +543,20 @@ void interface_options_photorec_ncurses(struct ph_options *options)
     menuOptions[2].name=options->mode_ext2?"ext2/ext3 mode: Yes":"ext2/ext3 mode : No";
     menuOptions[3].name=options->expert?"Expert mode : Yes":"Expert mode : No";
     menuOptions[4].name=options->lowmem?"Low memory: Yes":"Low memory: No";
+    snprintf(options_msg, sizeof(options_msg), "Min image file size: %llu bytes",
+	(long long unsigned)options->image_min_filesize);
+    menuOptions[5].name=options_msg;
+    snprintf(options_msg2, sizeof(options_msg2), "Min image width: %u px",
+	options->image_min_width);
+    menuOptions[6].name=options_msg2;
+    snprintf(options_msg3, sizeof(options_msg3), "Min image height: %u px",
+	options->image_min_height);
+    menuOptions[7].name=options_msg3;
+    snprintf(options_msg4, sizeof(options_msg4), "Min image area: %llu pixels",
+	(long long unsigned)options->image_min_pixels);
+    menuOptions[8].name=options_msg4;
     aff_copy(stdscr);
-    car=wmenuSelect_ext(stdscr, 23, INTER_OPTION_Y, INTER_OPTION_X, menuOptions, 0, "PKELQ", MENU_VERT|MENU_VERT_ARROW2VALID, &menu,&real_key);
+    car=wmenuSelect_ext(stdscr, 23, INTER_OPTION_Y, INTER_OPTION_X, menuOptions, 0, "PKSELWBHAQ", MENU_VERT|MENU_VERT_ARROW2VALID, &menu,&real_key);
     switch(car)
     {
       case 'p':
@@ -561,6 +581,22 @@ void interface_options_photorec_ncurses(struct ph_options *options)
       case 'l':
       case 'L':
 	options->lowmem=!options->lowmem;
+	break;
+      case 'b':
+      case 'B':
+	options->image_min_filesize=ask_number(options->image_min_filesize, 0, PHOTOREC_MAX_FILE_SIZE, "Minimum image file size in bytes ");
+	break;
+      case 'w':
+      case 'W':
+	options->image_min_width=(unsigned int)ask_number(options->image_min_width, 0, 4294967295ULL, "Minimum image width in pixels ");
+	break;
+      case 'h':
+      case 'H':
+	options->image_min_height=(unsigned int)ask_number(options->image_min_height, 0, 4294967295ULL, "Minimum image height in pixels ");
+	break;
+      case 'a':
+      case 'A':
+	options->image_min_pixels=ask_number(options->image_min_pixels, 0, PHOTOREC_MAX_FILE_SIZE, "Minimum image area in pixels ");
 	break;
       case key_ESC:
       case 'q':

--- a/src/poptions.c
+++ b/src/poptions.c
@@ -34,6 +34,13 @@
 #include "log.h"
 #include "poptions.h"
 
+static unsigned int uint64_to_uint_clamp(const uint64_t val)
+{
+  if(val > (uint64_t)(~0u))
+    return ~0u;
+  return (unsigned int)val;
+}
+
 void interface_options_photorec_cli(struct ph_options *options, char **current_cmd)
 {
   if(*current_cmd==NULL)
@@ -87,6 +94,22 @@ void interface_options_photorec_cli(struct ph_options *options, char **current_c
     {
       options->lowmem=1;
     }
+    else if(check_command(current_cmd,"image_min_filesize,",19)==0)
+    {
+      options->image_min_filesize=get_int_from_command(current_cmd);
+    }
+    else if(check_command(current_cmd,"image_min_width,",16)==0)
+    {
+      options->image_min_width=uint64_to_uint_clamp(get_int_from_command(current_cmd));
+    }
+    else if(check_command(current_cmd,"image_min_height,",17)==0)
+    {
+      options->image_min_height=uint64_to_uint_clamp(get_int_from_command(current_cmd));
+    }
+    else if(check_command(current_cmd,"image_min_pixels,",17)==0)
+    {
+      options->image_min_pixels=get_int_from_command(current_cmd);
+    }
     else
     {
 #ifndef DISABLED_FOR_FRAMAC
@@ -108,4 +131,9 @@ void interface_options_photorec_log(const struct ph_options *options)
       options->mode_ext2?"Yes":"No",
       options->expert?"Yes":"No",
       options->lowmem?"Yes":"No");
+  log_info(" Image minimum filesize : %llu\n Image minimum width : %u\n Image minimum height : %u\n Image minimum pixels : %llu\n",
+      (long long unsigned)options->image_min_filesize,
+      options->image_min_width,
+      options->image_min_height,
+      (long long unsigned)options->image_min_pixels);
 }

--- a/src/qphotorec.cpp
+++ b/src/qphotorec.cpp
@@ -67,7 +67,9 @@
 #include <QDialogButtonBox>
 #include <QSortFilterProxyModel>
 #include <QGroupBox>
+#include <QGridLayout>
 #include <QRadioButton>
+#include <QSpinBox>
 #include <QFileDialog>
 #include <QComboBox>
 #include <QTimer>
@@ -116,6 +118,10 @@ QPhotorec::QPhotorec(QWidget *my_parent) : QWidget(my_parent)
   options->mode_ext2=0;
   options->expert=0;
   options->lowmem=0;
+  options->image_min_filesize=0;
+  options->image_min_width=0;
+  options->image_min_height=0;
+  options->image_min_pixels=0;
   options->verbose=0;
   options->list_file_format=array_file_enable;
   reset_array_file_enable(options->list_file_format);
@@ -486,6 +492,7 @@ void QPhotorec::setupUI()
 
   QGroupBox *groupBox1;
   QGroupBox *groupBox2;
+  QGroupBox *groupBox3;
 
   groupBox1 = new QGroupBox(tr("File System type"));
   qextRadioButton = new QRadioButton(tr("ext2/ext3/ext4 filesystem"));
@@ -510,10 +517,35 @@ void QPhotorec::setupUI()
   groupBox2Layout->addWidget(qwholeRadioButton);
   groupBox2->setLayout(groupBox2Layout);
 
+  groupBox3 = new QGroupBox(tr("Image minimums"));
+  imageMinFilesizeSpinBox = new QSpinBox();
+  imageMinWidthSpinBox = new QSpinBox();
+  imageMinHeightSpinBox = new QSpinBox();
+  imageMinPixelsSpinBox = new QSpinBox();
+  imageMinFilesizeSpinBox->setRange(0, 2147483647);
+  imageMinWidthSpinBox->setRange(0, 65535);
+  imageMinHeightSpinBox->setRange(0, 65535);
+  imageMinPixelsSpinBox->setRange(0, 2147483647);
+  imageMinFilesizeSpinBox->setSuffix(tr(" bytes"));
+  imageMinWidthSpinBox->setSuffix(tr(" px"));
+  imageMinHeightSpinBox->setSuffix(tr(" px"));
+  imageMinPixelsSpinBox->setSuffix(tr(" pixels"));
+  QGridLayout *groupBox3Layout = new QGridLayout;
+  groupBox3Layout->addWidget(new QLabel(tr("File size")), 0, 0);
+  groupBox3Layout->addWidget(imageMinFilesizeSpinBox, 0, 1);
+  groupBox3Layout->addWidget(new QLabel(tr("Width")), 1, 0);
+  groupBox3Layout->addWidget(imageMinWidthSpinBox, 1, 1);
+  groupBox3Layout->addWidget(new QLabel(tr("Height")), 2, 0);
+  groupBox3Layout->addWidget(imageMinHeightSpinBox, 2, 1);
+  groupBox3Layout->addWidget(new QLabel(tr("Area")), 3, 0);
+  groupBox3Layout->addWidget(imageMinPixelsSpinBox, 3, 1);
+  groupBox3->setLayout(groupBox3Layout);
+
   QWidget *groupBox= new QWidget();
   QHBoxLayout *groupBoxLayout = new QHBoxLayout;
   groupBoxLayout->addWidget(groupBox1);
   groupBoxLayout->addWidget(groupBox2);
+  groupBoxLayout->addWidget(groupBox3);
   groupBox->setLayout(groupBoxLayout);
 
 
@@ -904,6 +936,10 @@ void QPhotorec::qphotorec_search()
   log_partition(selected_disk, selected_partition);
 
   options->mode_ext2=qextRadioButton->isChecked();
+  options->image_min_filesize=(uint64_t)imageMinFilesizeSpinBox->value();
+  options->image_min_width=(unsigned int)imageMinWidthSpinBox->value();
+  options->image_min_height=(unsigned int)imageMinHeightSpinBox->value();
+  options->image_min_pixels=(uint64_t)imageMinPixelsSpinBox->value();
 
   qphotorec_search_setupUI();
   if(td_list_empty(&list_search_space.list))

--- a/src/qphotorec.h
+++ b/src/qphotorec.h
@@ -23,6 +23,7 @@
 #include <QLabel>
 #include <QLineEdit>
 #include <QRadioButton>
+#include <QSpinBox>
 #include <QProgressBar>
 #include "types.h"
 #include "common.h"
@@ -86,6 +87,10 @@ class QPhotorec: public QWidget
 		QRadioButton 		*qfatRadioButton;
 		QRadioButton 		*qfreeRadioButton;
 		QRadioButton 		*qwholeRadioButton;
+		QSpinBox		*imageMinFilesizeSpinBox;
+		QSpinBox		*imageMinWidthSpinBox;
+		QSpinBox		*imageMinHeightSpinBox;
+		QSpinBox		*imageMinPixelsSpinBox;
 		/* Recovery UI */
 		QLabel			*folder_txt;
 		QLabel 			*progress_info;

--- a/src/sessionp.c
+++ b/src/sessionp.c
@@ -299,6 +299,14 @@ int session_save(const alloc_data_t *list_free_space, const struct ph_param *par
       fprintf(f_session, "expert,");
     if(options->lowmem>0)
       fprintf(f_session, "lowmem,");
+    if(options->image_min_filesize>0)
+      fprintf(f_session, "image_min_filesize,%llu,", (long long unsigned)options->image_min_filesize);
+    if(options->image_min_width>0)
+      fprintf(f_session, "image_min_width,%u,", options->image_min_width);
+    if(options->image_min_height>0)
+      fprintf(f_session, "image_min_height,%u,", options->image_min_height);
+    if(options->image_min_pixels>0)
+      fprintf(f_session, "image_min_pixels,%llu,", (long long unsigned)options->image_min_pixels);
     /* Save options - End */
     if(params->carve_free_space_only>0)
       fprintf(f_session,"freespace,");


### PR DESCRIPTION
Addresses #167.

This adds configurable image minimum filters for PhotoRec:

- minimum image file size in bytes
- minimum width and height
- minimum width multiplied by height
- JPEG and PNG enforcement paths
- `/cmd` option parsing and session save output
- ncurses PhotoRec options screen controls
- QPhotoRec controls for the same minimums
- man page note for the batch option names

I noticed #206 after starting this implementation. This PR is offered as an alternative, mainly because it also exposes the controls in QPhotoRec and checks JPEG dimensions again after validation if the SOF marker was not available in the initial header buffer. If maintainers prefer #206, I am happy to close this.

Verification:

- `git diff --check`
- `gcc -fsyntax-only -I src -DHAVE_STDINT_H -DHAVE_INTTYPES_H -DHAVE_SYS_TYPES_H -DHAVE_SYS_STAT_H -DHAVE_STRING_H -DHAVE_TIME_H -DHAVE_STDLIB_H src/filegen.c src/poptions.c src/photorec.c src/sessionp.c src/phrecn.c src/file_png.c src/file_jpg.c`

I could not run the full autotools build in this Windows workspace because generated configure files are not present and the portable toolchain used for verification does not include autotools.
