### PR TITLE
Fix typo in tlog.c

### DIFF
--- a/src/tlog.c
+++ b/src/tlog.c
@@ -62,7 +62,7 @@ int ask_testdisk_log_creation(void)
   wprintw(stdscr,"testdisk.log");
   if(has_colors())
     wbkgdset(stdscr,' ' | COLOR_PAIR(0));
-  wprintw(stdscr," , it");
+  wprintw(stdscr,", it");
   wmove(stdscr,12,0);
   wprintw(stdscr,"will contain TestDisk options, technical information and various");
   wmove(stdscr,13,0);


### PR DESCRIPTION
Remove the space between the bold "testdisk.log" and the comma