### PR TITLE
Fix stack out-of-bounds read in `ntfs_get_first_rl_element()`

### DIFF
--- a/src/ntfs.c
+++ b/src/ntfs.c
@@ -275,20 +275,29 @@ long int ntfs_get_first_rl_element(const ntfs_attribnonresident *attrnr, const c
   /* return first element of the run_list */
   /* buf must be unsigned! */
   const unsigned char *buf;
+  const unsigned char *attr_start=(const unsigned char *)attrnr;
+  const uint32_t attr_len=le32(attrnr->header.cbAttribute);
+  const uint16_t offDataRuns=le16(attrnr->offDataRuns);
   uint8_t b;                   	/* Current byte offset in buf. */
   const unsigned char*attr_end;     /* End of attribute. */
   int64_t deltaxcn = (int64_t)-1;	/* Change in [vl]cn. */
-  buf=(const unsigned char*)attrnr + le16(attrnr->offDataRuns);
-  attr_end = (const unsigned char*)attrnr + le32(attrnr->header.cbAttribute);
+  if((const char *)attr_start + sizeof(ntfs_attribnonresident) > end)
+    return 0;
+  if(attr_len < sizeof(ntfs_attribnonresident))
+    return 0;
+  attr_end = attr_start + attr_len;
   if((const char *)attr_end > end)
     return 0;
+  if(offDataRuns < sizeof(ntfs_attribnonresident) || offDataRuns >= attr_len)
+    return 0;
+  buf=attr_start + offDataRuns;
   b = *buf & 0xf;
   if(b==0)
   {
     log_error("Missing length entry in mapping pairs array.\n");
     return 0;
   }
-  if (buf + b > attr_end)
+  if (buf + b >= attr_end)
   {
     log_error("Attribut AT_DATA: bad size\n");
     return 0;
@@ -311,7 +320,7 @@ long int ntfs_get_first_rl_element(const ntfs_attribnonresident *attrnr, const c
     const uint8_t b2 = *buf & 0xf;
     long lcn=0;
     b = b2 + ((*buf >> 4) & 0xf);
-    if (buf + b > attr_end)
+    if (buf + b >= attr_end)
     {
       log_error("Attribut AT_DATA: bad size\n");
       return 0;


### PR DESCRIPTION
Fixes a stack out-of-bounds read in `ntfs_get_first_rl_element()` when
`rebuildbs` is run against an NTFS image whose $DATA attribute is shorter
than the nonresident header or whose `offDataRuns` points outside the
attribute. Rejects such attributes with `return 0` and tightens the two
existing mapping-pairs cursor checks from `>` to `>=`.

Issue originally reported privately by Team Atlanta and coordinated over email.